### PR TITLE
Align API service port with README

### DIFF
--- a/festive-events-frontend/src/app/services/api.ts
+++ b/festive-events-frontend/src/app/services/api.ts
@@ -7,7 +7,9 @@ import { User, FestiveEvent } from '../models/interfaces';
   providedIn: 'root'
 })
 export class ApiService {
-  private baseUrl = 'http://localhost:5000/api';
+  // Porta padrao definida no backend (launchSettings.json)
+  // README tambem referencia http://localhost:5213
+  private baseUrl = 'http://localhost:5213/api';
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## Summary
- update angular `ApiService` baseUrl to match README port of 5213

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5ea044e08324bb56f8b6423fb0df