### PR TITLE
Fix invalid JSON in development settings

### DIFF
--- a/FestiveEventsApi/appsettings.Development.json
+++ b/FestiveEventsApi/appsettings.Development.json
@@ -4,7 +4,7 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=MyAppDb;User Id=myuser;Password=mypassword;"
   }


### PR DESCRIPTION
## Summary
- fix missing comma in `appsettings.Development.json`
